### PR TITLE
v0.1.0.2: Support Cabal-3.12 (GHC 9.10)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20240110
+# version: 0.19.20240429
 #
-# REGENDATA ("0.17.20240110",["github","hackage-cli.cabal"])
+# REGENDATA ("0.19.20240429",["github","hackage-cli.cabal"])
 #
 name: Haskell-CI
 on:
@@ -27,19 +27,19 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:focal
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.1
+          - compiler: ghc-9.8.2
             compilerKind: ghc
-            compilerVersion: 9.8.1
+            compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.4
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.6.4
+            compilerVersion: 9.6.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -91,8 +91,9 @@ jobs:
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.3.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           apt-get update
           apt-get install -y libbrotli-dev
         env:
@@ -112,7 +113,7 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.3.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
@@ -205,7 +206,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -235,7 +236,7 @@ jobs:
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: always()
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.19.20240429
+# version: 0.19.20240630
 #
-# REGENDATA ("0.19.20240429",["github","hackage-cli.cabal"])
+# REGENDATA ("0.19.20240630",["github","hackage-cli.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.10.1
+            compilerKind: ghc
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.8.2
             compilerKind: ghc
             compilerVersion: 9.8.2
@@ -91,9 +96,8 @@ jobs:
           mkdir -p "$HOME/.ghcup/bin"
           curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.3.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           apt-get update
           apt-get install -y libbrotli-dev
         env:
@@ -113,7 +117,7 @@ jobs:
           echo "HC=$HC" >> "$GITHUB_ENV"
           echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
           echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.3.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
@@ -198,7 +202,7 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(Cabal|binary|hackage-cli)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|binary|hackage-cli)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -76,15 +76,15 @@ jobs:
     - name: Install dependencies
       # if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       run: |
-        stack build ${{ env.ARGS }} --test --only-dependencies
+        stack build ${{ env.ARGS }} --flag HsOpenSSL:use-pkg-config --test --only-dependencies
 
     - name: Build hackage-cli
       run: |
-        stack build ${{ env.ARGS }}
+        stack build ${{ env.ARGS }} --flag HsOpenSSL:use-pkg-config
 
     - name: Test hackage-cli
       run: |
-        stack test ${{ env.ARGS }}
+        stack test ${{ env.ARGS }} --flag HsOpenSSL:use-pkg-config
 
     - name: Cache dependencies (save)
       uses: actions/cache/save@v4

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,16 +14,17 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest]
-        ghc-ver: [9.8.1, 9.6.4]
+        ghc-ver: [9.8, 9.6]
           # Snapshots for 9.4.8, 9.2.8, 9.0.2, 8.10.7 do not have a recent enough base-compat; 0.13 is needed.
           # On ubuntu-22.04 the old versions 8.8.4, 8.6.5, 8.4.4, 8.2.2 fail due to HsOpenSSL linking errors.
           # They used to work under ubuntu-20.04, but it is not worth the trouble maintaining them.
           # Apparently, HsOpenSSL-0.11.6 and older are too old for ubuntu-22.04.
         include:
           - os: macos-latest
-            ghc-ver: 9.8.1
+            ghc-ver: 9.8
           - os: windows-latest
-            ghc-ver: 9.8.1
+            ghc-ver: 9.8
+
     env:
       ARGS: "--stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"
 
@@ -35,13 +36,19 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: haskell-actions/setup@v2
-      id: haskell-setup
+      id: setup
       with:
         ghc-version: ${{ matrix.ghc-ver }}
         enable-stack: true
 
+    - name: Set up the openssl library (MacOS)
+      if: runner.os == 'macOS'
+      run: |
+        echo "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}"
+        echo "PKG_CONFIG_PATH=$(brew --prefix)/opt/openssl/lib/pkgconfig" >> "${GITHUB_ENV}"
+
     - name: Install the brotli library (Windows)
-      if: ${{ runner.os == 'Windows' }}
+      if: runner.os == 'Windows'
         # Andreas Abel, 2022-02-15:
         # Stack is packing an old version of MSYS2.
         # To work around certification problems, we need to update msys2-keyring.
@@ -52,24 +59,19 @@ jobs:
         stack exec ${{ env.ARGS }} -- pacman --noconfirm -S mingw-w64-x86_64-openssl
 
     - name: Install the brotli library (Ubuntu)
-      if: ${{ runner.os == 'Linux' }}
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get install libbrotli-dev -qq
-
-    - name: Set environment variables based on Haskell setup
-      run: |
-        STACK_VER=$(stack --numeric-version)
-        echo "STACK_VER=${STACK_VER}" >> "${GITHUB_ENV}"
 
     - name: Cache dependencies (restore)
       uses: actions/cache/restore@v4
       id: cache
       with:
-        path: ${{ steps.haskell-setup.outputs.stack-root }}
+        path: ${{ steps.setup.outputs.stack-root }}
         # Use a unique primary key (always save new cache); works if caches aren't to big or too many...
-        key:          ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ matrix.ghc-ver }}-commit-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ matrix.ghc-ver }}-
+        key:          ${{ runner.os }}-stack-${{ steps.setup.outputs.stack-version }}-ghc-${{ steps.setup.outputs.ghc-version }}-commit-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-stack-${{ steps.setup.outputs.stack-version }}-ghc-${{ steps.setup.outputs.ghc-version }}-
 
     - name: Install dependencies
       # if: ${{ steps.cache.outputs.cache-hit != 'true' }}
@@ -86,9 +88,8 @@ jobs:
 
     - name: Cache dependencies (save)
       uses: actions/cache/save@v4
-      if: always()
+      if: always() && steps.cache.outputs.cache-hit != 'true'
       # # Will fail if we already have a cache with this key (in this case, cache-hit is true).
-      # if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       with:
-        path: ${{ steps.haskell-setup.outputs.stack-root }}
+        path: ${{ steps.setup.outputs.stack-root }}
         key:  ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -13,17 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:      [ubuntu-latest]
-        ghc-ver: [9.8, 9.6]
+        os:      [ubuntu-latest,macos-latest,windows-latest]
+        ghc-ver: ['9.10', '9.8', '9.6']
           # Snapshots for 9.4.8, 9.2.8, 9.0.2, 8.10.7 do not have a recent enough base-compat; 0.13 is needed.
           # On ubuntu-22.04 the old versions 8.8.4, 8.6.5, 8.4.4, 8.2.2 fail due to HsOpenSSL linking errors.
           # They used to work under ubuntu-20.04, but it is not worth the trouble maintaining them.
           # Apparently, HsOpenSSL-0.11.6 and older are too old for ubuntu-22.04.
-        include:
-          - os: macos-latest
-            ghc-ver: 9.8
-          - os: windows-latest
-            ghc-ver: 9.8
+        # include:
+        #   - os: macos-latest
+        #     ghc-ver: '9.10'
+        #   - os: windows-latest
+        #     ghc-ver: '9.10'
 
     env:
       ARGS: "--stack-yaml=stack-${{ matrix.ghc-ver }}.yaml --no-terminal --system-ghc"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # Changelog for hackage-cli
 
+## 0.1.0.2
+
+_Andreas Abel, 2024-07-02_
+
+- Allow revision of `stability` field
+  (`hackage-server` issue [#1182](https://github.com/haskell/hackage-server/issues/1182)).
+- Print correct revision in `push-cabal --incr-rev`
+  (issue [#66](https://github.com/hackage-trustees/hackage-cli/issues/66)).
+- Fix for `Cabal-3.12.0.0`.
+
+Builds with `Cabal 3.4 - 3.12` and `GHC 8.2 - 9.10`.
+
 ## 0.1.0.1
 
 _Andreas Abel, 2023-02-20_
 
-- Fix for `Cabal-3.9.0.0`
+- Fix for `Cabal-3.9.0.0`.
 
 Builds with `Cabal 3.4 - 3.9` and `GHC 8.2 - 9.6`.
 
@@ -12,11 +24,11 @@ Builds with `Cabal 3.4 - 3.9` and `GHC 8.2 - 9.6`.
 
 _Andreas Abel, 2023-01-15_
 
-- Skip errors when running `add-bound` on several files.
-  (PR [#42](https://github.com/hackage-trustees/hackage-cli/pull/42))
+- Skip errors when running `add-bound` on several files
+  (PR [#42](https://github.com/hackage-trustees/hackage-cli/pull/42)).
 
-- If no version range is given for a dependency, interpret it as `-any` rather than _none_ (`<0`).
-  (PR [#48](https://github.com/hackage-trustees/hackage-cli/pull/48))
+- If no version range is given for a dependency, interpret it as `-any` rather than _none_ (`<0`)
+  (PR [#48](https://github.com/hackage-trustees/hackage-cli/pull/48)).
 
 Builds with `Cabal 3.4 - 3.8` and `GHC 8.2 - 9.4`.
 

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                hackage-cli
-version:             0.1.0.1
+version:             0.1.0.2
 
 synopsis:            CLI tool for Hackage
 description:
@@ -18,6 +18,7 @@ build-type:          Simple
 -- Supported GHC versions when building with cabal:
 tested-with:
   -- Keep in descending order.
+  GHC == 9.10.1
   GHC == 9.8.2
   GHC == 9.6.5
   GHC == 9.4.8
@@ -53,7 +54,7 @@ library cabal-revisions
   build-depends:
     , base         >= 4.10.0.0 && < 5
     , bytestring   >= 0.10.4.0 && < 0.13
-    , Cabal        >= 3.4      && < 3.11
+    , Cabal        >= 3.4      && < 3.13
     , containers   >= 0.5.0.0  && < 0.8
     , mtl          >= 2.2.2    && < 2.3   || >= 2.3.1 && < 2.4
     , pretty      ^>= 1.1.2

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -18,8 +18,8 @@ build-type:          Simple
 -- Supported GHC versions when building with cabal:
 tested-with:
   -- Keep in descending order.
-  GHC == 9.8.1
-  GHC == 9.6.4
+  GHC == 9.8.2
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -37,12 +37,8 @@ extra-source-files:
   fixtures/*.diff
   fixtures/*.cabal
   -- Supported GHC versions when building with stack:
-  stack-9.8.1.yaml
-  stack-9.6.4.yaml
-  stack-9.4.8.yaml
-  stack-9.2.8.yaml
-  stack-9.0.2.yaml
-  stack-8.10.7.yaml
+  stack-9.8.yaml
+  stack-9.6.yaml
 
 source-repository head
   Type:     git
@@ -55,7 +51,7 @@ library cabal-revisions
   ghc-options:         -Wall -Wcompat
 
   build-depends:
-    , base         >= 4.10.0.0 && < 4.20
+    , base         >= 4.10.0.0 && < 5
     , bytestring   >= 0.10.4.0 && < 0.13
     , Cabal        >= 3.4      && < 3.11
     , containers   >= 0.5.0.0  && < 0.8
@@ -79,7 +75,7 @@ test-suite cabal-revisions-tests
     , tasty         >= 1.0      && < 1.6
         -- tasty-1.0 for stack-8.2.2.yaml
     , tasty-golden ^>= 2.3.2
-    , filepath     ^>= 1.4.0.0
+    , filepath      >= 1.4.0.0  && < 1.6
 
 executable hackage-cli
   default-language:    Haskell2010
@@ -134,8 +130,8 @@ executable hackage-cli
     , tagsoup               ^>= 0.14
     , tar                    >= 0.5      && < 1
     , text                   >= 1.2      && < 2.2
-    , time                   >= 1.5.0.1  && < 1.13
+    , time                   >= 1.5.0.1  && < 1.15
     , unordered-containers  ^>= 0.2.7
-    , zlib                  ^>= 0.6.1
+    , zlib                   >= 0.6.1    && < 0.8
 
   ghc-options: -Wall -Wcompat -threaded

--- a/lib/Distribution/Server/Util/CabalRevisions.hs
+++ b/lib/Distribution/Server/Util/CabalRevisions.hs
@@ -12,7 +12,7 @@
 -- Copyright   :  Duncan Coutts et al.
 -- SPDX-License-Identifier: BSD-3-Clause
 --
--- Maintainer  :  libraries@haskell.org
+-- Maintainer  :  Andreas Abel
 -- Stability   :  provisional
 -- Portability :  portable
 --
@@ -178,8 +178,15 @@ checkCabalFileRevision checkXRevision old new = do
 
     checkPackageChecks :: Check GenericPackageDescription
     checkPackageChecks pkg pkg' =
-      let checks  = checkPackage pkg  Nothing
-          checks' = checkPackage pkg' Nothing
+      let checks  = checkPackage pkg
+-- The API change of checkPackage happened somewhere between 3.10 and 3.12.
+#if !MIN_VERSION_Cabal(3,12,0)
+                      Nothing
+#endif
+          checks' = checkPackage pkg'
+#if !MIN_VERSION_Cabal(3,12,0)
+                      Nothing
+#endif
        in case checks' \\ checks of
             []        -> return ()
             newchecks -> fail $ unlines (map ppPackageCheck newchecks)

--- a/stack-9.10.yaml
+++ b/stack-9.10.yaml
@@ -1,0 +1,23 @@
+resolver: nightly-2024-07-01
+compiler: ghc-9.10.1
+compiler-check: match-exact
+
+# Libraries shipped with GHC 9.10.1:
+extra-deps:
+- Cabal-3.12.0.0
+- Cabal-syntax-3.12.0.0
+- directory-1.3.8.3
+- filepath-1.5.2.0
+- process-1.6.19.0
+- unix-2.8.5.1
+# For Windows:
+- Win32-2.14.0.0
+- time-1.12.2
+
+flags:
+  directory:
+    os-string: true
+  unix:
+    os-string: true
+  Win32:
+    os-string: true

--- a/stack-9.4.8.yaml
+++ b/stack-9.4.8.yaml
@@ -1,3 +1,7 @@
 resolver: lts-21.25
 compiler: ghc-9.4.8
 compiler-check: match-exact
+
+# Cannot easily update base-compat in this snapshot
+# extra-deps:
+# - base-compat-0.13.1

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -1,1 +1,1 @@
-resolver: lts-22.21
+resolver: lts-22.27

--- a/stack-9.6.yaml
+++ b/stack-9.6.yaml
@@ -1,0 +1,1 @@
+resolver: lts-22.21

--- a/stack-9.8.yaml
+++ b/stack-9.8.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2024-05-11
+resolver: nightly-2024-07-01

--- a/stack-9.8.yaml
+++ b/stack-9.8.yaml
@@ -1,0 +1,1 @@
+resolver: nightly-2024-05-11


### PR DESCRIPTION
https://hackage.haskell.org/package/hackage-cli-0.1.0.2/candidate