### PR TITLE
ghc 9.14

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20250506",["github","hackage-cli.cabal"])
+# REGENDATA ("0.19.20250821",["github","hackage-cli.cabal"])
 #
 name: Haskell-CI
 on:
@@ -32,6 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.0.20250819
+            compilerKind: ghc
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
@@ -106,11 +111,26 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
           HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
@@ -132,7 +152,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -160,6 +180,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -208,9 +240,16 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_hackage_cli}" >> cabal.project
           echo "package hackage-cli" >> cabal.project
-          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package hackage-cli" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package hackage-cli" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(Cabal|binary|hackage-cli)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:      [ubuntu-latest,macos-latest,windows-latest]
-        ghc-ver: ['9.10', '9.8', '9.6']
+        ghc-ver: ['9.12', '9.10', '9.8', '9.6']
           # Snapshots for 9.4.8, 9.2.8, 9.0.2, 8.10.7 do not have a recent enough base-compat; 0.13 is needed.
           # On ubuntu-22.04 the old versions 8.8.4, 8.6.5, 8.4.4, 8.2.2 fail due to HsOpenSSL linking errors.
           # They used to work under ubuntu-20.04, but it is not worth the trouble maintaining them.
@@ -34,7 +34,7 @@ jobs:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: haskell-actions/setup@v2
       id: setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for hackage-cli
 
+## 0.1.0.4
+
+_Andreas Abel, 2025-08-30_
+
+- Remove unused dependencies of test-suite
+
+Builds with `Cabal 3.4 - 3.16` and `GHC 8.2 - 9.14 alpha1`.
+
 ## 0.1.0.3
 
 _Andreas Abel, 2025-06-04_

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -39,6 +39,7 @@ extra-source-files:
   fixtures/*.diff
   fixtures/*.cabal
   -- Supported GHC versions when building with stack:
+  stack-9.12.yaml
   stack-9.10.yaml
   stack-9.8.yaml
   stack-9.6.yaml

--- a/hackage-cli.cabal
+++ b/hackage-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                hackage-cli
-version:             0.1.0.3
+version:             0.1.0.4
 
 synopsis:            CLI tool for Hackage
 description:
@@ -18,6 +18,7 @@ build-type:          Simple
 -- Supported GHC versions when building with cabal:
 tested-with:
   -- Keep in descending order.
+  GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.2
   GHC == 9.8.4
@@ -57,7 +58,7 @@ library cabal-revisions
   build-depends:
     , base         >= 4.10.0.0 && < 5
     , bytestring   >= 0.10.4.0 && < 0.13
-    , Cabal        >= 3.4      && < 3.15
+    , Cabal        >= 3.4      && < 3.17
     , containers   >= 0.5.0.0  && < 0.8
     , mtl          >= 2.2.2    && < 2.3   || >= 2.3.1 && < 2.4
     , pretty      ^>= 1.1.2
@@ -129,13 +130,11 @@ executable hackage-cli
     , netrc                 ^>= 0.2.0.0
     , optparse-applicative   >= 0.14     && < 1
     , process-extras        ^>= 0.7.4
-    , semigroups             >= 0.18.3   && < 0.21
     , stringsearch          ^>= 0.3.6
     , tagsoup               ^>= 0.14
     , tar                    >= 0.5      && < 1
     , text                   >= 1.2      && < 2.2
     , time                   >= 1.5.0.1  && < 1.15
-    , unordered-containers  ^>= 0.2.7
     , zlib                   >= 0.6.1    && < 0.8
 
   ghc-options: -Wall -Wcompat -threaded

--- a/src/IndexShaSum.hs
+++ b/src/IndexShaSum.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
+#if __GLASGOW_HASKELL__ >= 900
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+#endif
+
 -- |
 -- Module      :  IndexShaSum
 -- Copyright   :  Herbert Valerio Riedel

--- a/stack-9.12.yaml
+++ b/stack-9.12.yaml
@@ -1,5 +1,5 @@
-resolver: lts-24.7
-compiler: ghc-9.10.2
+resolver: nightly-2025-08-30
+compiler: ghc-9.12.2
 compiler-check: match-exact
 
 flags:

--- a/stack-9.8.yaml
+++ b/stack-9.8.yaml
@@ -1,4 +1,4 @@
-resolver: lts-23.24
+resolver: lts-23.28
 
 flags:
   HsOpenSSL:


### PR DESCRIPTION
- **Bump Stack CI to GHC 9.12**
  

- **v0.1.0.4: drop unused dependencies from test-suite**
  

Candidate: https://hackage.haskell.org/package/hackage-cli-0.1.0.4/candidate