### PR TITLE
Workaround for hackage-server currently not accepting hackage-cli user-agent

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -120,7 +120,8 @@ hcReqLeft = hcReqCnt . to f
 setUA :: RequestBuilder ()
 setUA = setHeader "User-Agent" uaStr
   where
-    uaStr = "hackage-cli/" <> BS8.pack (V.showVersion Paths_hackage_cli.version)
+    uaStr = "curl/" <> BS8.pack (V.showVersion Paths_hackage_cli.version)
+    -- uaStr = "hackage-cli/" <> BS8.pack (V.showVersion Paths_hackage_cli.version)
 
 hackageSendGET :: ByteString -> ByteString -> HIO ()
 hackageSendGET p a = do


### PR DESCRIPTION
User agent has been added in https://github.com/haskell/hackage-server/pull/1493 but is not live yet.

Build `hackage-cli` from this PR in the meantime.
